### PR TITLE
✏️ 배포 알림 메세지에 닫는 중괄호 오타 제거

### DIFF
--- a/src/infrastructures/implementDeploymentService.ts
+++ b/src/infrastructures/implementDeploymentService.ts
@@ -23,7 +23,7 @@ export const implementDeploymentService = ({
         const contributorsText =
           otherContributors.length === 0 ? '' : ` cc. ${otherContributors.map(formatMemberMention).join(', ')}`;
         return {
-          text: [`${formatEmoji('rocket')} *${repository}/${tag}* ${authorText}${contributorsText}}`, summarized].join(
+          text: [`${formatEmoji('rocket')} *${repository}/${tag}* ${authorText}${contributorsText}`, summarized].join(
             '\n\n',
           ),
         };


### PR DESCRIPTION
닫는 괄호 `}` 껴있어서 제거합니다.