### PR TITLE
👽 위클리 대시보드 채널 active-2023-2 에서 active-2024-1 로 변경

### DIFF
--- a/.github/workflows/weekly-dashboard.yml
+++ b/.github/workflows/weekly-dashboard.yml
@@ -27,7 +27,7 @@ jobs:
       - name: run script
         run: |
           yarn install
-          SLACK_WEEKLY_CHANNEL_ID=C05PP0Q6SS1 \
+          SLACK_WEEKLY_CHANNEL_ID=C06M9K1LT36 \
           SLACK_AUTH_TOKEN=${{ secrets.SLACK_AUTH_TOKEN }} \
           GHP_ACCESS_TOKEN=${{ secrets.GHP_ACCESS_TOKEN }} \
           GITHUB_ORGANIZATION=wafflestudio \


### PR DESCRIPTION
https://wafflestudio.slack.com/archives/C05PP0Q6SS1/p1710081675579809?thread_ts=1709520369.819369&cid=C05PP0Q6SS1